### PR TITLE
[17.0][FIX] hr_shift: Allow assigning shifts with leaves/public holidays to a template without error (similar to v14)

### DIFF
--- a/hr_shift/models/shift_planning.py
+++ b/hr_shift/models/shift_planning.py
@@ -262,11 +262,17 @@ class ShiftPlanningShift(models.Model):
             )
             shift_lines = []
             for shift_date in dates:
+                day_number = str(shift_date["weekday"])
+                exist_line = shift.line_ids.filtered(
+                    lambda x, day_number=day_number: x.day_number == day_number
+                )
+                if exist_line:
+                    continue
                 shift_lines.append(
                     {
                         "shift_id": shift.id,
                         "template_id": shift.template_id.id,
-                        "day_number": str(shift_date["weekday"]),
+                        "day_number": day_number,
                     }
                 )
             shift.line_ids.create(shift_lines)
@@ -277,7 +283,11 @@ class ShiftPlanningShift(models.Model):
         template = self.env["hr.shift.template"].browse(vals["template_id"] or 0)
         self.filtered(
             lambda x: x.template_id != template or not x.template_id
-        ).line_ids.unlink()
+        ).line_ids.filtered(
+            # Do not delete lines in order to try to create them later and cause the
+            # constraint error
+            lambda x: x.state not in {"holiday", "on_leave"}
+        ).unlink()
         res = super().write(vals)
         self._generate_shift_lines()
         return res

--- a/hr_shift/tests/test_hr_shift.py
+++ b/hr_shift/tests/test_hr_shift.py
@@ -67,6 +67,16 @@ class TestHrShift(TestHrShiftBase):
         self.assertTrue(shift_a_line_0.reviewed)
         shift_a_line_1 = shift_a.line_ids.filtered(lambda x: x.day_number == "1")
         self.assertEqual(shift_a_line_1.state, "unassigned")
+        self.assertFalse(shift_a.template_id)
+        self.assertFalse(shift_a_line_0.template_id)
+        self.assertFalse(shift_a_line_1.template_id)
+        template_morning = self.env.ref("hr_shift.template_morning")
+        shift_a.write({"template_id": template_morning.id})
+        self.assertEqual(shift_a.template_id, template_morning)
+        self.assertFalse(shift_a_line_0.template_id)
+        self.assertFalse(shift_a_line_1.exists())
+        shift_a_line_1 = shift_a.line_ids.filtered(lambda x: x.day_number == "1")
+        self.assertEqual(shift_a_line_1.template_id, template_morning)
 
     @mute_logger("odoo.models.unlink")
     def test_hr_shift_planning_full(self):


### PR DESCRIPTION
Allow assigning shifts with leaves/public holidays to a template without error (similar to v14). Related to https://github.com/OCA/shift-planning/pull/14#discussion_r2302983405

**v14**
![ejemplo-v14](https://github.com/user-attachments/assets/318b70c7-70b0-4764-b0ea-a192137da534)

**v17**
![ejemplo-v17](https://github.com/user-attachments/assets/44bbc2ef-bf21-4516-872a-933da9d2cea1)

Please @pedrobaeza and @david-banon-tecnativa can you review it?

@Tecnativa