### PR TITLE
[17.0][FIX] hr_shift: prevent shift planning being counted as lunch

### DIFF
--- a/hr_shift/models/resource_calendar.py
+++ b/hr_shift/models/resource_calendar.py
@@ -38,7 +38,7 @@ class ResourceCalendar(models.Model):
         res = super()._attendance_intervals_batch(
             start_dt, end_dt, resources, domain, tz, lunch
         )
-        if resources:
+        if resources and not lunch:
             shift_ids = self._resource_shift_for_datetime_range(
                 start_dt, end_dt, resources, tz=tz
             )


### PR DESCRIPTION
[FIX] hr_shift: prevent shift planning being counted as lunch

This fixes a bug in the hr_shift module where shift planning records were treated as "lunch"
during worked hours calculation, subtracting them from the employee's worked hours.

Now, the planned shifts are correctly counted as regular working hours.

Closes #20 