### PR TITLE
[17.0][FIX] hr_shift: Prevent TypeError

### DIFF
--- a/hr_shift/models/resource_calendar.py
+++ b/hr_shift/models/resource_calendar.py
@@ -58,7 +58,13 @@ class ResourceCalendar(models.Model):
                     ]
                     start_time = string_to_datetime(shift.start_time).astimezone(tz)
                     end_time = string_to_datetime(shift.end_time).astimezone(tz)
-                    intervals_to_add.append((start_time, end_time, shift))
+                    # noqa: E501 Prevent TypeError: inconsistent models in: 'hr.shift.planning.line()' in 'resource.calendar.attendance()'
+                    interval_to_add_item = (
+                        resource_intervals[0][2] if resource_intervals else shift
+                    )
+                    intervals_to_add.append(
+                        (start_time, end_time, interval_to_add_item)
+                    )
                 res[resource.id]._items = [
                     x for x in resource_intervals if x not in intervals_to_remove
                 ] + intervals_to_add


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/shift-planning/pull/23

Prevent `TypeError`

Use case example:
- Create an `hr.shift.planning.line` record with a start time of 00:00:00 and an end time of 08:00:00
- The employee must have a work schedule after 08:00:00 (for example, starting at 13:00:00)
- The report from the `hr_attendance_report_theoretical_time` module is used. The `hr_shift` methods will mix records and cause an error.

`TypeError: inconsistent models in: 'hr.shift.planning.line()' inand 'resource.calendar.attendance()'`

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT60298