### PR TITLE
[18.0][FIX] hr_shift: Replace calendar attendances by date

### DIFF
--- a/hr_shift/models/resource_calendar.py
+++ b/hr_shift/models/resource_calendar.py
@@ -47,13 +47,15 @@ class ResourceCalendar(models.Model):
                 intervals_to_remove = []
                 resource_intervals = res[resource.id]._items
                 for shift in shifts:
+                    # Remove any other interval that belongs to any of the dates of the
+                    # shift (no matter the hours, as if the shift is around midnight,
+                    # there will be a mix of 2 dates)
                     intervals_to_remove += [
                         (start, end, resource_item)
                         for start, end, resource_item in resource_intervals
                         if (
-                            shift.start_time
-                            >= datetime.combine(start, start.min.time())
-                            and shift.end_time >= datetime.combine(end, end.min.time())
+                            shift.start_time.date() == start.date()
+                            or shift.end_time.date() == end.date()
                         )
                     ]
                     start_time = string_to_datetime(shift.start_time).astimezone(tz)


### PR DESCRIPTION
Forward-port of #28 

This module replaces theoretical calendar attendances by the shift ones in a conservative way, only removing those that belong to the exact shift. That way, if no shift is specified, the usual calendar will apply.

But when the shift is at or around midnight, there can be 2 dates involved, the starting day, and the ending day. If the calendar assigned to the employee has attendance entries in both of them, the replacing of them won't be correct.

Thus, we should remove all the attendances entries belonging to any of the days of the shift, no matter the hours.

@Tecnativa TT61053