### PR TITLE
[17.0][IMP] hr_shift: add active to shift templates

### DIFF
--- a/hr_shift/i18n/es.po
+++ b/hr_shift/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-19 09:53+0000\n"
-"PO-Revision-Date: 2025-08-19 09:53+0000\n"
+"POT-Creation-Date: 2026-04-17 10:23+0000\n"
+"PO-Revision-Date: 2026-04-17 10:23+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -23,6 +23,17 @@ msgid "%(day)s shifts of %(planning)s"
 msgstr "Turnos del %(day)s para %(planning)s"
 
 #. module: hr_shift
+#: model:ir.model.fields,field_description:hr_shift.field_hr_shift_template__active
+msgid "Active"
+msgstr "Activo"
+
+#. module: hr_shift
+#: model_terms:ir.ui.view,arch_db:hr_shift.shift_template_form
+#: model_terms:ir.ui.view,arch_db:hr_shift.shift_template_search
+msgid "Archived"
+msgstr "Archivado"
+
+#. module: hr_shift
 #: model:ir.model.fields.selection,name:hr_shift.selection__hr_shift_planning_line__state__assigned
 msgid "Assigned"
 msgstr "Asignado"
@@ -35,7 +46,7 @@ msgstr "Asignación"
 #. module: hr_shift
 #: model:ir.model,name:hr_shift.model_hr_employee_base
 msgid "Basic Employee"
-msgstr "Empleado Básico"
+msgstr "Empleado básico"
 
 #. module: hr_shift
 #: model_terms:ir.ui.view,arch_db:hr_shift.shift_planning_wizard_form
@@ -144,6 +155,11 @@ msgid "Days Data"
 msgstr "Datos del día"
 
 #. module: hr_shift
+#: model_terms:ir.ui.view,arch_db:hr_shift.res_config_settings_view_form
+msgid "Default Working Week"
+msgstr "Semana laboral por defecto"
+
+#. module: hr_shift
 #: model:ir.model.fields,field_description:hr_shift.field_hr_shift_planning__display_name
 #: model:ir.model.fields,field_description:hr_shift.field_hr_shift_planning_line__display_name
 #: model:ir.model.fields,field_description:hr_shift.field_hr_shift_planning_shift__display_name
@@ -222,8 +238,8 @@ msgstr "Generar"
 
 #. module: hr_shift
 #. odoo-javascript
-#: code:addons/hr_shift/static/src/js/generate_planning.js:0
-#: code:addons/hr_shift/static/src/js/generate_planning.js:0
+#: code:addons/hr_shift/static/src/js/generate_planning.esm.js:0
+#: code:addons/hr_shift/static/src/js/generate_planning.esm.js:0
 #: code:addons/hr_shift/static/src/xml/generate_planning_views.xml:0
 #, python-format
 msgid "Generate Planning"
@@ -269,7 +285,7 @@ msgstr "Tipo de generación"
 #. module: hr_shift
 #: model_terms:ir.ui.view,arch_db:hr_shift.shift_planning_line_search
 msgid "Group By"
-msgstr ""
+msgstr "Agrupar por"
 
 #. module: hr_shift
 #: model:ir.model.fields.selection,name:hr_shift.selection__hr_shift_planning_line__state__holiday

--- a/hr_shift/i18n/hr_shift.pot
+++ b/hr_shift/i18n/hr_shift.pot
@@ -21,6 +21,17 @@ msgid "%(day)s shifts of %(planning)s"
 msgstr ""
 
 #. module: hr_shift
+#: model:ir.model.fields,field_description:hr_shift.field_hr_shift_template__active
+msgid "Active"
+msgstr ""
+
+#. module: hr_shift
+#: model_terms:ir.ui.view,arch_db:hr_shift.shift_template_form
+#: model_terms:ir.ui.view,arch_db:hr_shift.shift_template_search
+msgid "Archived"
+msgstr ""
+
+#. module: hr_shift
 #: model:ir.model.fields.selection,name:hr_shift.selection__hr_shift_planning_line__state__assigned
 msgid "Assigned"
 msgstr ""

--- a/hr_shift/models/shift_template.py
+++ b/hr_shift/models/shift_template.py
@@ -37,6 +37,7 @@ class ShiftTemplate(models.Model):
         help="This field is used in order to define in which timezone the employees "
         "will work.",
     )
+    active = fields.Boolean(default=True)
 
     def _prepare_time(self):
         def _parse_float_time(float_time):

--- a/hr_shift/views/shift_template_views.xml
+++ b/hr_shift/views/shift_template_views.xml
@@ -5,6 +5,13 @@
         <field name="arch" type="xml">
             <form>
                 <sheet>
+                    <field name="active" invisible="1" />
+                    <widget
+                        name="web_ribbon"
+                        title="Archived"
+                        bg_color="bg-danger"
+                        invisible="active"
+                    />
                     <group>
                         <group>
                             <field name="name" />
@@ -36,6 +43,18 @@
                 <field name="day_of_week_end" />
                 <field name="tz" />
             </tree>
+        </field>
+    </record>
+    <record id="shift_template_search" model="ir.ui.view">
+        <field name="model">hr.shift.template</field>
+        <field name="arch" type="xml">
+            <search>
+                <filter
+                    string="Archived"
+                    name="inactive"
+                    domain="[('active','=',False)]"
+                />
+            </search>
         </field>
     </record>
     <record id="shift_template_action" model="ir.actions.act_window">


### PR DESCRIPTION
Add active field to `hr.shift.template` model to allow archive shifts that are no longer in use.